### PR TITLE
Slightly updated installation instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,8 +4,17 @@ A DSL for GRACeFUL components.
 
 ## Installing
 
-`GenericLibrary` requires MiniZinc. We provide installation instructions for
-Linux and macOS.
+In order to use `GenericLibrary`, the following software dependencies must be
+met: 
+
+* [The MiniZinc distribution](http://www.minizinc.org/index.html)
+* [GHC](https://www.haskell.org/downloads)
+
+To ensure that software dependencies are exactly met, we recommend that you use
+`stack`. `stack` handles the entire toolchain (including GHC), library 
+dependencies, building and executing. Instructions for installing `stack` on 
+macOS, Linux and Windows can be found 
+[here](https://docs.haskellstack.org/en/stable/install_and_upgrade/).
 
 ### Linux
 

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ met:
 * [The MiniZinc distribution](http://www.minizinc.org/index.html)
 * [GHC](https://www.haskell.org/downloads)
 
-To ensure that software dependencies are exactly met, we recommend that you use
+To ensure that library dependencies are exactly met, we recommend that you use
 `stack`. `stack` handles the entire toolchain (including GHC), library 
 dependencies, building and executing. Instructions for installing `stack` on 
 macOS, Linux and Windows can be found 

--- a/Readme.md
+++ b/Readme.md
@@ -16,11 +16,11 @@ dependencies, building and executing. Instructions for installing `stack` on
 macOS, Linux and Windows can be found 
 [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/).
 
-### Linux
+### Installing MiniZinc: Linux
 
 Patrik has provided an [install script](doc/INSTALL.md) for Linux.
 
-### macOS
+### Installing MiniZinc: macOS
 
 1. Download and install the complete MiniZinc distribution from
   [the MiniZinc page](http://www.minizinc.org/index.html).

--- a/Readme.md
+++ b/Readme.md
@@ -28,8 +28,8 @@ Patrik has provided an [install script](doc/INSTALL.md) for Linux.
   `/Applications/MiniZincIDE.app/Contents/Resources`. Add this directory to your
   path, like so:
 
-      export PATH='$PATH:/Applications/MiniZincIDE.app/Contents/Resources'
-
+      export PATH="$PATH:/Applications/MiniZincIDE.app/Contents/Resources"
+      
 ## Running a constraint program
 
 ### Using sandboxes


### PR DESCRIPTION
[Readme.md](Readme.md) has been slightly updated to provide links for installing `stack`, which seems to be the easiest thing we can provide for someone who does not already have familiarity with the Haskell toolchain - seeing as it manages that automatically. Also, some typos corrected.