### PR TITLE
add note about `stack docker pull` in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,9 @@ stack build
 stack exec examples
 ```
 
+(Note: you might have to execute `stack docker pull` before executing `stack build` if you receive an error message such as `
+Error: No such object: fpco/stack-build:lts-7.11`)
+
 Copy executables to `~/.local/bin` (put them on PATH) with
 
 ```shell


### PR DESCRIPTION
I had to execute `stack docker pull` first, maybe that could be added to the instructions (log: https://gist.github.com/rubenpieters/7bc98bd0d86e582c8240dc4b60b0b54e )

I got the solution from: http://haskell-channel-logs.blogspot.be/2017/01/haskell-channel-featuring-bengt-janosp.html